### PR TITLE
Fix loop logic and tsconfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,11 +92,11 @@ export async function findFirstSignature(
 
     if (sigInfos.length === 0) {
       if (earliestSig) {
-         foundAllSignatures = true;
+        foundAllSignatures = true;
+        break;
       } else {
         throw new NoSignaturesFoundError(programPubkey.toBase58());
       }
-      break;
     }
 
     earliestSig = sigInfos[sigInfos.length - 1].signature;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": []
   },
   "exclude": ["tests"]
 }


### PR DESCRIPTION
## Summary
- correct unreachable break when no signatures are found
- tweak tsconfig to disable automatic @types inclusion

## Testing
- `npx tsc --noEmit` *(fails: Cannot find name 'process')*

------
https://chatgpt.com/codex/tasks/task_e_683f464770b8832d8dde4e3a1b574f0e