### PR TITLE
fix README command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npm start -- <PROGRAM_ID> [options]
   * **Get timestamp for the Memo Program using a specific custom endpoint:**
 
     ```bash
-    npm start -- Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo -e [https://api.mainnet-beta.solana.com](https://api.mainnet-beta.solana.com)
+    npm start -- Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo -e https://api.mainnet-beta.solana.com
     ```
 
   * **Using a Helius RPC endpoint via environment variable:**


### PR DESCRIPTION
## Summary
- fix Memo Program example to use a plain URL

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f49bfc2f4832da59b1dc1810c3237